### PR TITLE
Tailwind fails if `lektor build` run from outside the Lektor project directory

### DIFF
--- a/lektor_tailwind.py
+++ b/lektor_tailwind.py
@@ -65,6 +65,7 @@ class TailwindPlugin(Plugin):
                 "--minify",
             ],
             check=True,
+            cwd=self.env.root_path,
         )
 
     def on_server_spawn(self, **extra):

--- a/lektor_tailwind.py
+++ b/lektor_tailwind.py
@@ -22,7 +22,7 @@ class TailwindPlugin(Plugin):
         self.watch = False
         self.css_path = config.get("css_path", "static/style.css")
         self.input_css = os.path.join(self.env.root_path, "assets", self.css_path)
-        self.tailwind: threading.Thread | None = None
+        self.tailwind: subprocess.Popen | None = None
 
     def on_setup_env(self, **extra):
         self.init_tailwindcss()


### PR DESCRIPTION
Since relative paths are used to configure the `content` paths in `tailwind.config.js`, tailwind can not find the source content unless it is run from the Lektor project directory.

Lektor-tailwind currently fails to chdir to the Lektor project directory before running tailwind for `lektor build`.  (It does chdir before running tailwind in watch mode for `lektor server`.)

This fixes that.