### PR TITLE
Minimize CSS when running `lektor server` with NODE_ENV=production

### DIFF
--- a/lektor_tailwind.py
+++ b/lektor_tailwind.py
@@ -39,17 +39,19 @@ class TailwindPlugin(Plugin):
     def _run_watcher(self, output_path: str):
         if not self.input_exists():
             return
-        self.tailwind = subprocess.Popen(
-            [
-                self.tailwind_bin,
-                "-i",
-                self.input_css,
-                "-o",
-                os.path.join(output_path, self.css_path),
-                "-w",
-            ],
-            cwd=self.env.root_path,
-        )
+
+        cmd = [
+            self.tailwind_bin,
+            "--input",
+            self.input_css,
+            "--output",
+            os.path.join(output_path, self.css_path),
+            "--watch",
+        ]
+        if os.environ.get("NODE_ENV") == "production":
+            cmd.append("--minify")
+
+        self.tailwind = subprocess.Popen(cmd, cwd=self.env.root_path)
 
     def input_exists(self) -> bool:
         return os.path.exists(self.input_css)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -163,7 +163,13 @@ class LektorServerFixture:
 
 
 @pytest.fixture
-def lektor_server(tmp_project_path):
+def node_env():
+    return "development"
+
+
+@pytest.fixture
+def lektor_server(tmp_project_path, node_env, monkeypatch):
+    monkeypatch.setenv("NODE_ENV", node_env)
     with LektorServerFixture() as fixture:
         yield fixture
 
@@ -202,3 +208,11 @@ def test_server_rebuilds_css_when_input_css_updated(
     lektor_server.wait_for_build()
     assert ".SENTINEL" in output_css_path.read_text()
     assert ".flex" in output_css_path.read_text()
+
+
+@pytest.mark.parametrize("node_env", ["production"])
+def test_server_build_minified(lektor_server, output_css_path, node_env):
+    lektor_server.wait_for_build()
+    assert ".flex" in output_css_path.read_text()
+    lines_of_css = len(output_css_path.read_text().splitlines())
+    assert lines_of_css == 1


### PR DESCRIPTION
Currently, the generated CSS is minimized when running `lektor build`, but not when running `lektor server`.

If one publishes their site using the "Publish" button in the Lektor GUI, one publishes un-minimized CSS.

This PR minimizes the CSS in `lektor server` mode if the `$NODE_ENV` environment variable is set to `"production"`.

----

**NOTE**: This PR is stacked on PR #4.  It should be merged *after* that one. (It may also require rebasing, depending on how #4 is merged.)